### PR TITLE
Update oauth-subscriber dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/oauth-subscriber": "^0.2.0"
+        "guzzlehttp/oauth-subscriber": "^0.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/oauth-subscriber": "^0.3.0"
+        "guzzlehttp/oauth-subscriber": "~0.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
oauth-subscriber 0.2.0 doesn't work with guzzle 6+, version 0.3.0 works as expected.
